### PR TITLE
outgoing: avoid "-Werror=declaration-after-statement" warning with static_assert

### DIFF
--- a/src/n-dhcp4-outgoing.c
+++ b/src/n-dhcp4-outgoing.c
@@ -54,8 +54,6 @@
 int n_dhcp4_outgoing_new(NDhcp4Outgoing **outgoingp, size_t max_size, uint8_t overload) {
         _c_cleanup_(n_dhcp4_outgoing_freep) NDhcp4Outgoing *outgoing = NULL;
 
-        c_assert(!(overload & ~(N_DHCP4_OVERLOAD_FILE | N_DHCP4_OVERLOAD_SNAME)));
-
         /*
          * Make sure the minimum limit is bigger than the maximum protocol
          * header plus the DHCP-message-header plus a single OPTION_END byte.
@@ -63,6 +61,8 @@ int n_dhcp4_outgoing_new(NDhcp4Outgoing **outgoingp, size_t max_size, uint8_t ov
         static_assert(N_DHCP4_NETWORK_IP_MINIMUM_MAX_SIZE >= N_DHCP4_OUTGOING_MAX_PHDR +
                                                              sizeof(NDhcp4Message) + 1,
                       "Invalid minimum IP packet limit");
+
+        c_assert(!(overload & ~(N_DHCP4_OVERLOAD_FILE | N_DHCP4_OVERLOAD_SNAME)));
 
         outgoing = calloc(1, sizeof(*outgoing));
         if (!outgoing)


### PR DESCRIPTION
```
  $ CFLAGS='-Werror=declaration-after-statement' meson build && ninja -C build
  ...
  [36/47] Compiling C object 'src/25a6634@@ndhcp4-private@sta/n-dhcp4-outgoing.c.o'.
  FAILED: src/25a6634@@ndhcp4-private@sta/n-dhcp4-outgoing.c.o
  ccache cc -Isrc/25a6634@@ndhcp4-private@sta -Isrc -I../src -Isubprojects/c-list/src -I../subprojects/c-list/src -Isubprojects/c-siphash/src -I../subprojects/c-siphash/src -Isubprojects/c-stdaux/src -I../subprojects/c-stdaux/src -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c11 -g -D_GNU_SOURCE -Werror=declaration-after-statement -fPIC -fvisibility=hidden -fno-common -MD -MQ 'src/25a6634@@ndhcp4-private@sta/n-dhcp4-outgoing.c.o' -MF 'src/25a6634@@ndhcp4-private@sta/n-dhcp4-outgoing.c.o.d' -o 'src/25a6634@@ndhcp4-private@sta/n-dhcp4-outgoing.c.o' -c ../src/n-dhcp4-outgoing.c
  ../src/n-dhcp4-outgoing.c: In function ‘n_dhcp4_outgoing_new’:
  ../src/n-dhcp4-outgoing.c:63:9: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
     63 |         static_assert(N_DHCP4_NETWORK_IP_MINIMUM_MAX_SIZE >= N_DHCP4_OUTGOING_MAX_PHDR +
        |         ^~~~~~~~~~~~~
```

