### PR TITLE
probe: allocate memory of right size in n_dhcp4_client_probe_option_new()

### DIFF
--- a/src/n-dhcp4-c-probe.c
+++ b/src/n-dhcp4-c-probe.c
@@ -26,7 +26,7 @@ static int n_dhcp4_client_probe_option_new(NDhcp4ClientProbeOption **optionp,
                                     uint8_t n_data) {
         NDhcp4ClientProbeOption *op;
 
-        op = malloc(sizeof(op) + n_data);
+        op = malloc(sizeof(*op) + n_data);
         if (!op)
                 return -ENOMEM;
 


### PR DESCRIPTION
Non-critical, as the allocated memory was larger than needed.

https://gitlab.freedesktop.org/NetworkManager/NetworkManager/issues/224

Signed-off-by: Thomas Haller <thaller@redhat.com>