### PR TITLE
probe: arm timers in bound state

### DIFF
--- a/src/n-dhcp4-c-probe.c
+++ b/src/n-dhcp4-c-probe.c
@@ -1009,7 +1009,7 @@ int n_dhcp4_client_probe_transition_accept(NDhcp4ClientProbe *probe, NDhcp4Incom
 
                 probe->state = N_DHCP4_CLIENT_PROBE_STATE_BOUND;
 
-                /* XXX: trigger timers */
+		n_dhcp4_client_arm_timer(probe->client);
 
                 break;
 


### PR DESCRIPTION
Arm timers in bound state, otherwise the lease is never renewed.

Signed-off-by: Beniamino Galvani <bgalvani@redhat.com>