### PR TITLE
Add API for retrieving lease timestamp and fix handling of infinite lifetimes

### DIFF
--- a/src/n-dhcp4-c-lease.c
+++ b/src/n-dhcp4-c-lease.c
@@ -44,10 +44,7 @@ static int n_dhcp4_incoming_get_timeouts(NDhcp4Incoming *message, uint64_t *t1p,
         } else if (u32 == UINT32_MAX) {
                 lifetime = UINT64_MAX;
         } else {
-                if (u32 == UINT32_MAX)
-                        lifetime = UINT64_MAX;
-                else
-                        lifetime = u32 * (1000000000ULL);
+                lifetime = u32 * (1000000000ULL);
         }
 
         r = n_dhcp4_incoming_query_t2(message, &u32);

--- a/src/n-dhcp4-c-lease.c
+++ b/src/n-dhcp4-c-lease.c
@@ -204,6 +204,18 @@ _c_public_ void n_dhcp4_client_lease_get_yiaddr(NDhcp4ClientLease *lease, struct
 }
 
 /**
+ * n_dhcp4_client_lease_get_basetime() - get the timestamp when the lease was received.
+ * @lease:                      the lease to operate on
+ * @ns_basetimep:               return argument for the base time in nano seconds
+ *
+ * Gets the timestamp when the lease was received in CLOCK_BOOTTIME. This
+ * is also the base timestamp for the expiration of the lifetime and t1/t2.
+ */
+_c_public_ void n_dhcp4_client_lease_get_basetime(NDhcp4ClientLease *lease, uint64_t *ns_basetimep) {
+        *ns_basetimep = lease->message->userdata.base_time;
+}
+
+/**
  * n_dhcp4_client_lease_get_lifetime() - get the lifetime
  * @lease:                      the lease to operate on
  * @ns_lifetimep:               return argument for the lifetime in nano seconds

--- a/src/n-dhcp4-c-probe.c
+++ b/src/n-dhcp4-c-probe.c
@@ -836,7 +836,8 @@ static int n_dhcp4_client_probe_transition_offer(NDhcp4ClientProbe *probe, NDhcp
         case N_DHCP4_CLIENT_PROBE_STATE_REBINDING:
         case N_DHCP4_CLIENT_PROBE_STATE_EXPIRED:
         default:
-                /* ignore */
+                /* ignore, but consume message. */
+                n_dhcp4_incoming_free(message);
                 break;
         }
 
@@ -885,7 +886,7 @@ static int n_dhcp4_client_probe_transition_ack(NDhcp4ClientProbe *probe, NDhcp4I
                 if (r)
                         return r;
 
-                /* message consumed, don to fail */
+                /* message consumed, do not fail */
 
                 n_dhcp4_client_lease_link(lease, probe);
 
@@ -903,7 +904,8 @@ static int n_dhcp4_client_probe_transition_ack(NDhcp4ClientProbe *probe, NDhcp4I
         case N_DHCP4_CLIENT_PROBE_STATE_GRANTED:
         case N_DHCP4_CLIENT_PROBE_STATE_EXPIRED:
         default:
-                /* ignore */
+                /* ignore, but consume message. */
+                n_dhcp4_incoming_free(message);
                 break;
         }
 

--- a/src/n-dhcp4-incoming.c
+++ b/src/n-dhcp4-incoming.c
@@ -365,10 +365,7 @@ static int n_dhcp4_incoming_query_u32(NDhcp4Incoming *message, uint8_t option, u
 
         memcpy(&be32, data, sizeof(be32));
 
-        if (be32 == (uint32_t)-1)
-                *u32p = 0;
-        else
-                *u32p = ntohl(be32);
+        *u32p = ntohl(be32);
         return 0;
 }
 

--- a/src/n-dhcp4.h
+++ b/src/n-dhcp4.h
@@ -156,6 +156,7 @@ NDhcp4ClientLease *n_dhcp4_client_lease_ref(NDhcp4ClientLease *lease);
 NDhcp4ClientLease *n_dhcp4_client_lease_unref(NDhcp4ClientLease *lease);
 
 void n_dhcp4_client_lease_get_yiaddr(NDhcp4ClientLease *lease, struct in_addr *yiaddr);
+void n_dhcp4_client_lease_get_basetime(NDhcp4ClientLease *lease, uint64_t *ns_basetimep);
 void n_dhcp4_client_lease_get_lifetime(NDhcp4ClientLease *lease, uint64_t *ns_lifetimep);
 int n_dhcp4_client_lease_query(NDhcp4ClientLease *lease, uint8_t option, uint8_t **datap, size_t *n_datap);
 


### PR DESCRIPTION
- add `n_dhcp4_client_lease_get_basetime()` API
- don't coerce `0xFFFFFFFF` to 0.


This doesn't address what does it actually mean to have a lease time with lifetime zero... compare this to systemd, which would coerce 0 to 1...