### PR TITLE
client-probe: fix state transitions on timer dispatch

### DIFF
--- a/src/n-dhcp4-c-probe.c
+++ b/src/n-dhcp4-c-probe.c
@@ -1100,16 +1100,17 @@ int n_dhcp4_client_probe_dispatch_timer(NDhcp4ClientProbe *probe, uint64_t ns_no
                         r = n_dhcp4_client_probe_transition_lifetime(probe);
                         if (r)
                                 return r;
-                } else if (ns_now >= probe->current_lease->t2) {
+                } else if (ns_now >= probe->current_lease->t2 &&
+                           probe->state != N_DHCP4_CLIENT_PROBE_STATE_REBINDING) {
                         r = n_dhcp4_client_probe_transition_t2(probe, ns_now);
                         if (r)
                                 return r;
-                } else if (ns_now >= probe->current_lease->t1) {
+                } else if (ns_now >= probe->current_lease->t1 &&
+                           probe->state == N_DHCP4_CLIENT_PROBE_STATE_BOUND) {
                         r = n_dhcp4_client_probe_transition_t1(probe, ns_now);
                         if (r)
                                 return r;
                 }
-
                 break;
         default:
                 /* ignore */


### PR DESCRIPTION
Currently in any of the BOUND, RENEWING and REBINDING states the probe
checks the expiration of T1, T2 and lifetime. This is not correct
because, for example, if the timer fires in the RENEWING state, the
probe must not transition to RENEWING again (i.e. check again that
now >= T1). Note that there is no guarantee that the timer triggers
exactly once for T1, T2 and lifetime expirations because the timer is
also used for the retransmission logic in NDhcp4CConnection.

Therefore, add some checks to ensure that only correct transitions are
allowed.

Signed-off-by: Beniamino Galvani <bgalvani@redhat.com>