### PR TITLE
[th/build-centos76] adjust code to build on CentOS7.6

### DIFF
--- a/src/n-dhcp4-c-connection.c
+++ b/src/n-dhcp4-c-connection.c
@@ -8,6 +8,8 @@
 #include <c-stdaux.h>
 #include <errno.h>
 #include <limits.h>
+#include <sys/socket.h> /* needed by linux/netdevice.h */
+#include <linux/netdevice.h>
 #include <net/if_arp.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/src/n-dhcp4-client.c
+++ b/src/n-dhcp4-client.c
@@ -183,7 +183,11 @@ _c_public_ void n_dhcp4_client_config_set_request_broadcast(NDhcp4ClientConfig *
  */
 _c_public_ void n_dhcp4_client_config_set_mac(NDhcp4ClientConfig *config, const uint8_t *mac, size_t n_mac) {
         config->n_mac = n_mac;
-        memcpy(config->mac, mac, c_min(n_mac, sizeof(config->mac)));
+
+        if (n_mac > sizeof(config->mac))
+                n_mac = sizeof(config->mac);
+
+        memcpy(config->mac, mac, n_mac);
 }
 
 /**
@@ -209,7 +213,11 @@ _c_public_ void n_dhcp4_client_config_set_mac(NDhcp4ClientConfig *config, const 
  */
 _c_public_ void n_dhcp4_client_config_set_broadcast_mac(NDhcp4ClientConfig *config, const uint8_t *mac, size_t n_mac) {
         config->n_broadcast_mac = n_mac;
-        memcpy(config->broadcast_mac, mac, c_min(n_mac, sizeof(config->broadcast_mac)));
+
+        if (n_mac > sizeof(config->mac))
+                n_mac = sizeof(config->mac);
+
+        memcpy(config->broadcast_mac, mac, n_mac);
 }
 
 /**

--- a/src/n-dhcp4-outgoing.c
+++ b/src/n-dhcp4-outgoing.c
@@ -220,8 +220,9 @@ int n_dhcp4_outgoing_append(NDhcp4Outgoing *outgoing,
                 /* try fitting into allowed OPTIONs space */
                 if (outgoing->max_size - outgoing->i_message >= n_data + 2U + 3U + 1U) {
                         /* try over-allocation to reduce allocation pressure */
-                        n = c_min(outgoing->max_size,
-                                  outgoing->n_message + n_data + 128);
+                        n = outgoing->n_message + n_data + 128;
+                        if (n > outgoing->max_size)
+                                n = outgoing->max_size;
                         m = realloc(outgoing->message, n);
                         if (!m)
                                 return -ENOMEM;

--- a/src/n-dhcp4-private.h
+++ b/src/n-dhcp4-private.h
@@ -7,7 +7,6 @@
 #include <endian.h>
 #include <inttypes.h>
 #include <limits.h>
-#include <linux/netdevice.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <time.h>
@@ -234,9 +233,9 @@ struct NDhcp4ClientConfig {
         int ifindex;
         unsigned int transport;
         bool request_broadcast;
-        uint8_t mac[MAX_ADDR_LEN];
+        uint8_t mac[32]; /* MAX_ADDR_LEN */
         size_t n_mac;
-        uint8_t broadcast_mac[MAX_ADDR_LEN];
+        uint8_t broadcast_mac[32]; /* MAX_ADDR_LEN */
         size_t n_broadcast_mac;
         uint8_t *client_id;
         size_t n_client_id;

--- a/src/n-dhcp4-socket.c
+++ b/src/n-dhcp4-socket.c
@@ -5,16 +5,17 @@
 #include <c-stdaux.h>
 #include <errno.h>
 #include <linux/filter.h>
+#include <sys/socket.h> /* needed by linux/if.h */
+#include <linux/if.h>
 #include <linux/if_packet.h>
+#include <linux/netdevice.h>
 #include <linux/udp.h>
-#include <net/if.h>
 #include <netinet/ip.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include "n-dhcp4-private.h"
 #include "util/packet.h"
 #include "util/socket.h"

--- a/src/util/packet.h
+++ b/src/util/packet.h
@@ -7,7 +7,6 @@
 #include <c-stdaux.h>
 #include <inttypes.h>
 #include <linux/if_packet.h>
-#include <linux/netdevice.h>
 #include <netinet/in.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -25,7 +24,7 @@ struct packet_sockaddr_ll {
         unsigned short  sll_hatype;
         unsigned char   sll_pkttype;
         unsigned char   sll_halen;
-        unsigned char   sll_addr[MAX_ADDR_LEN];
+        unsigned char   sll_addr[32]; /* MAX_ADDR_LEN */
 };
 
 uint16_t packet_internet_checksum(const uint8_t *data, size_t len);


### PR DESCRIPTION
Tom did these two patches for NetworkManager's fork.

NetworkManager currently has a fork of n-dhcp4. Via git-subtree, that is maintainable well, as long as we avoid deviating from upstream.

Currently we carry these two extra patches. I think we should avoid all differences as much as possible.


Possible `c_min()` should be made working with this compiler. But that might compromise its purpose of being a C11 library...