### PR TITLE
client: close timer file descriptor explicitly when EPOLL_CTL_ADD fails

### DIFF
--- a/src/n-dhcp4-client.c
+++ b/src/n-dhcp4-client.c
@@ -373,8 +373,11 @@ _c_public_ int n_dhcp4_client_new(NDhcp4Client **clientp, NDhcp4ClientConfig *co
 
         ev.data.u32 = N_DHCP4_CLIENT_EPOLL_TIMER;
         r = epoll_ctl(client->fd_epoll, EPOLL_CTL_ADD, client->fd_timer, &ev);
-        if (r < 0)
+        if (r < 0) {
+                close(client->fd_timer);
+                client->fd_timer = -1;
                 return -errno;
+        }
 
         *clientp = client;
         client = NULL;


### PR DESCRIPTION
When epoll_ctl(EPOLL_CTL_ADD) fails, the client instance gets destroyed.
This will see client->fd_timer set and will try to remove the file descriptor
from fd_epoll, although it was not successfully added in the first place.

It's not a severe problem to call EPOLL_CTL_DEL for the non registered,
albeit valid file descriptor. The call would simply fail with ENOENT. Still,
avoid it, such failures look odd in the strace output when they shouldn't
be there.