### PR TITLE
n-dhcp4/socket: use SO_REUSEADDR on UDP socket

### DIFF
--- a/src/n-dhcp4-socket.c
+++ b/src/n-dhcp4-socket.c
@@ -194,6 +194,10 @@ int n_dhcp4_c_socket_udp_new(int *sockfdp,
         if (sockfd < 0)
                 return -errno;
 
+        r = setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+        if (r < 0)
+                return -errno;
+
         r = setsockopt(sockfd, SOL_SOCKET, SO_ATTACH_FILTER, &fprog, sizeof(fprog));
         if (r < 0)
                 return -errno;


### PR DESCRIPTION
Otherwise, other applications cannot bind to port 0.0.0.0:68 at the same time.
This is for example what dhclient wants to do. So even when running
dhclient on another, unrelated interface, it would fail to bind the UDP
socket and quit.

Note that also systemd-networkd's DHCPv4 client sets this socket option.
Presumably for the same reasons.

Signed-off-by: Thomas Haller <thaller@redhat.com>