### PR TITLE
n-dhcp4: support init-reboot state

### DIFF
--- a/src/n-dhcp4-c-connection.c
+++ b/src/n-dhcp4-c-connection.c
@@ -137,6 +137,9 @@ int n_dhcp4_c_connection_listen(NDhcp4CConnection *connection) {
         _c_cleanup_(c_closep) int fd_packet = -1;
         int r;
 
+        if (connection->state == N_DHCP4_C_CONNECTION_STATE_PACKET)
+                return 0;
+
         c_assert(connection->state == N_DHCP4_C_CONNECTION_STATE_INIT);
 
         r = n_dhcp4_c_socket_packet_new(&fd_packet, connection->client_config->ifindex);
@@ -317,7 +320,6 @@ void n_dhcp4_c_connection_get_timeout(NDhcp4CConnection *connection,
         switch (connection->request->userdata.type) {
         case N_DHCP4_C_MESSAGE_DISCOVER:
         case N_DHCP4_C_MESSAGE_SELECT:
-        case N_DHCP4_C_MESSAGE_REBOOT:
         case N_DHCP4_C_MESSAGE_INFORM:
                 /*
                  * Resend with an exponential backoff and a one second random
@@ -336,6 +338,7 @@ void n_dhcp4_c_connection_get_timeout(NDhcp4CConnection *connection,
                 break;
         case N_DHCP4_C_MESSAGE_REBIND:
         case N_DHCP4_C_MESSAGE_RENEW:
+        case N_DHCP4_C_MESSAGE_REBOOT:
                 /*
                  * Resend every sixty seconds with a one second random slack.
                  *

--- a/src/n-dhcp4-c-probe.c
+++ b/src/n-dhcp4-c-probe.c
@@ -170,8 +170,6 @@ _c_public_ void n_dhcp4_client_probe_config_set_inform_only(NDhcp4ClientProbeCon
  * INIT-REBOOT path, as described by the DHCP specification. In most cases, you
  * do not want this.
  *
- * XXX: This is currently not implemented, and setting the property has no effect.
- *
  * Background: The INIT-REBOOT path allows a DHCP client to skip
  *             server-discovery when rebooting/resuming their machine. The DHCP
  *             client simply re-requests the lease it had acquired before. This
@@ -438,11 +436,17 @@ int n_dhcp4_client_probe_new(NDhcp4ClientProbe **probep,
         if (r)
                 return r;
 
+        if (probe->config->init_reboot && probe->config->requested_ip.s_addr != INADDR_ANY)
+                probe->state = N_DHCP4_CLIENT_PROBE_STATE_INIT_REBOOT;
+        else
+                probe->state = N_DHCP4_CLIENT_PROBE_STATE_INIT;
+
         if (active) {
                 /*
                  * Defer the sending of DISCOVER by a random amount (by default up to 9 seconds).
                  */
-                probe->ns_deferred = ns_now + (n_dhcp4_client_probe_config_get_random(probe->config) % (probe->config->ms_start_delay * 1000000ULL));
+                if (probe->state == N_DHCP4_CLIENT_PROBE_STATE_INIT)
+                        probe->ns_deferred = ns_now + (n_dhcp4_client_probe_config_get_random(probe->config) % (probe->config->ms_start_delay * 1000000ULL));
                 probe->client->current_probe = probe;
         } else {
                 r = n_dhcp4_client_probe_raise(probe,
@@ -575,6 +579,14 @@ void n_dhcp4_client_probe_get_timeout(NDhcp4ClientProbe *probe, uint64_t *timeou
         n_dhcp4_c_connection_get_timeout(&probe->connection, &timeout);
 
         switch (probe->state) {
+        case N_DHCP4_CLIENT_PROBE_STATE_INIT_REBOOT:
+                /* send DHCP request immediately */
+                timeout = 1;
+                break;
+        case N_DHCP4_CLIENT_PROBE_STATE_REBOOTING:
+                if (probe->ns_reinit && (!timeout || probe->ns_reinit < timeout))
+                        timeout = probe->ns_reinit;
+                break;
         case N_DHCP4_CLIENT_PROBE_STATE_INIT:
                 if (probe->ns_deferred && (!timeout || probe->ns_deferred < timeout))
                         timeout = probe->ns_deferred;
@@ -626,6 +638,52 @@ static int n_dhcp4_client_probe_outgoing_append_options(NDhcp4ClientProbe *probe
         return 0;
 }
 
+static int n_dhcp4_client_probe_transition_reboot(NDhcp4ClientProbe *probe, uint64_t ns_now) {
+        _c_cleanup_(n_dhcp4_outgoing_freep) NDhcp4Outgoing *request = NULL;
+        int r;
+
+        switch (probe->state) {
+        case N_DHCP4_CLIENT_PROBE_STATE_INIT_REBOOT:
+                r = n_dhcp4_c_connection_listen(&probe->connection);
+                if (r)
+                        return r;
+
+                r = n_dhcp4_c_connection_reboot_new(&probe->connection, &request, &probe->config->requested_ip);
+                if (r)
+                        return r;
+
+                r = n_dhcp4_client_probe_outgoing_append_options(probe, request);
+                if (r)
+                        return r;
+
+                r = n_dhcp4_c_connection_start_request(&probe->connection, request, ns_now);
+                if (r)
+                        return r;
+                else
+                        request = NULL; /* consumed */
+
+                probe->state = N_DHCP4_CLIENT_PROBE_STATE_REBOOTING;
+                probe->ns_reinit = ns_now + 2000000000ULL;
+
+                break;
+
+        case N_DHCP4_CLIENT_PROBE_STATE_SELECTING:
+        case N_DHCP4_CLIENT_PROBE_STATE_INIT:
+        case N_DHCP4_CLIENT_PROBE_STATE_REBOOTING:
+        case N_DHCP4_CLIENT_PROBE_STATE_REQUESTING:
+        case N_DHCP4_CLIENT_PROBE_STATE_GRANTED:
+        case N_DHCP4_CLIENT_PROBE_STATE_BOUND:
+        case N_DHCP4_CLIENT_PROBE_STATE_RENEWING:
+        case N_DHCP4_CLIENT_PROBE_STATE_REBINDING:
+        case N_DHCP4_CLIENT_PROBE_STATE_EXPIRED:
+        default:
+                abort();
+                break;
+        }
+
+        return 0;
+}
+
 static int n_dhcp4_client_probe_transition_deferred(NDhcp4ClientProbe *probe, uint64_t ns_now) {
         _c_cleanup_(n_dhcp4_outgoing_freep) NDhcp4Outgoing *request = NULL;
         int r;
@@ -635,12 +693,14 @@ static int n_dhcp4_client_probe_transition_deferred(NDhcp4ClientProbe *probe, ui
                 r = n_dhcp4_c_connection_listen(&probe->connection);
                 if (r)
                         return r;
+                /* fall-through */
 
+        case N_DHCP4_CLIENT_PROBE_STATE_REBOOTING:
                 r = n_dhcp4_c_connection_discover_new(&probe->connection, &request);
                 if (r)
                         return r;
 
-                if (probe->config->requested_ip.s_addr != INADDR_ANY) {
+                if (!probe->config->init_reboot && probe->config->requested_ip.s_addr != INADDR_ANY) {
                         r = n_dhcp4_outgoing_append_requested_ip(request, probe->config->requested_ip);
                         if (r)
                                 return r;
@@ -663,7 +723,6 @@ static int n_dhcp4_client_probe_transition_deferred(NDhcp4ClientProbe *probe, ui
 
         case N_DHCP4_CLIENT_PROBE_STATE_SELECTING:
         case N_DHCP4_CLIENT_PROBE_STATE_INIT_REBOOT:
-        case N_DHCP4_CLIENT_PROBE_STATE_REBOOTING:
         case N_DHCP4_CLIENT_PROBE_STATE_REQUESTING:
         case N_DHCP4_CLIENT_PROBE_STATE_GRANTED:
         case N_DHCP4_CLIENT_PROBE_STATE_BOUND:
@@ -870,10 +929,11 @@ static int n_dhcp4_client_probe_transition_ack(NDhcp4ClientProbe *probe, NDhcp4I
                 n_dhcp4_client_lease_unref(probe->current_lease);
                 probe->current_lease = n_dhcp4_client_lease_ref(lease);
                 probe->state = N_DHCP4_CLIENT_PROBE_STATE_BOUND;
-
+                probe->ns_nak_restart_delay = 0;
                 break;
 
         case N_DHCP4_CLIENT_PROBE_STATE_REQUESTING:
+        case N_DHCP4_CLIENT_PROBE_STATE_REBOOTING:
 
                 r = n_dhcp4_client_probe_raise(probe,
                                                &node,
@@ -892,13 +952,12 @@ static int n_dhcp4_client_probe_transition_ack(NDhcp4ClientProbe *probe, NDhcp4I
                 node->event.granted.lease = n_dhcp4_client_lease_ref(lease);
                 probe->current_lease = n_dhcp4_client_lease_ref(lease);
                 probe->state = N_DHCP4_CLIENT_PROBE_STATE_GRANTED;
-
+                probe->ns_nak_restart_delay = 0;
                 break;
 
         case N_DHCP4_CLIENT_PROBE_STATE_INIT:
         case N_DHCP4_CLIENT_PROBE_STATE_SELECTING:
         case N_DHCP4_CLIENT_PROBE_STATE_INIT_REBOOT:
-        case N_DHCP4_CLIENT_PROBE_STATE_REBOOTING:
         case N_DHCP4_CLIENT_PROBE_STATE_BOUND:
         case N_DHCP4_CLIENT_PROBE_STATE_GRANTED:
         case N_DHCP4_CLIENT_PROBE_STATE_EXPIRED:
@@ -928,9 +987,11 @@ static int n_dhcp4_client_probe_transition_nak(NDhcp4ClientProbe *probe) {
                         return r;
 
                 probe->state = N_DHCP4_CLIENT_PROBE_STATE_INIT;
-
+                probe->ns_deferred = n_dhcp4_gettime(CLOCK_BOOTTIME) + probe->ns_nak_restart_delay;
+                probe->ns_nak_restart_delay = C_CLAMP(probe->ns_nak_restart_delay * 2u,
+                                                      UINT64_C(2)   * UINT64_C(1000000000),
+                                                      UINT64_C(300) * UINT64_C(1000000000));
                 break;
-
         case N_DHCP4_CLIENT_PROBE_STATE_SELECTING:
         case N_DHCP4_CLIENT_PROBE_STATE_INIT_REBOOT:
         case N_DHCP4_CLIENT_PROBE_STATE_INIT:
@@ -1077,6 +1138,19 @@ int n_dhcp4_client_probe_dispatch_timer(NDhcp4ClientProbe *probe, uint64_t ns_no
         int r;
 
         switch (probe->state) {
+        case N_DHCP4_CLIENT_PROBE_STATE_INIT_REBOOT:
+                r = n_dhcp4_client_probe_transition_reboot(probe, ns_now);
+                if (r)
+                        return r;
+                break;
+        case N_DHCP4_CLIENT_PROBE_STATE_REBOOTING:
+                if (ns_now >= probe->ns_reinit) {
+                        r = n_dhcp4_client_probe_transition_deferred(probe, ns_now);
+                        if (r)
+                                return r;
+                }
+
+                break;
         case N_DHCP4_CLIENT_PROBE_STATE_INIT:
                 if (ns_now >= probe->ns_deferred) {
                         r = n_dhcp4_client_probe_transition_deferred(probe, ns_now);

--- a/src/n-dhcp4-private.h
+++ b/src/n-dhcp4-private.h
@@ -343,6 +343,8 @@ struct NDhcp4ClientProbe {
 
         unsigned int state;                     /* current probe state */
         uint64_t ns_deferred;                   /* timeout for deferred action */
+        uint64_t ns_reinit;
+        uint64_t ns_nak_restart_delay;          /* restart delay after a nak */
         NDhcp4ClientLease *current_lease;       /* current lease */
 
         NDhcp4CConnection connection;           /* client connection wrapper */


### PR DESCRIPTION
Currently the client always starts from the INIT state (i.e. sending a
discover message). If a requested-ip was specified by the caller, it
is added as an option in the discover.

It was reported that some DHCP servers don't respond to discover
messages with the requested-ip option set [1][2].

The RFC allows to skip the discover by entering the INIT-REBOOT state
and starting directly with a broadcast request message containing the
requested IP address. Implement that.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1781856
[2] https://gitlab.freedesktop.org/NetworkManager/NetworkManager/issues/310