### PR TITLE
n-dhcp4: use packet socket in rebinding state

### DIFF
--- a/src/n-dhcp4-c-connection.c
+++ b/src/n-dhcp4-c-connection.c
@@ -137,7 +137,19 @@ int n_dhcp4_c_connection_listen(NDhcp4CConnection *connection) {
         _c_cleanup_(c_closep) int fd_packet = -1;
         int r;
 
-        c_assert(connection->state == N_DHCP4_C_CONNECTION_STATE_INIT);
+        c_assert(connection->state == N_DHCP4_C_CONNECTION_STATE_INIT ||
+                 connection->state == N_DHCP4_C_CONNECTION_STATE_DRAINING ||
+                 connection->state == N_DHCP4_C_CONNECTION_STATE_UDP);
+
+        if (connection->fd_packet >= 0) {
+                epoll_ctl(connection->fd_epoll, EPOLL_CTL_DEL, connection->fd_packet, NULL);
+                connection->fd_packet = c_close(connection->fd_packet);
+        }
+
+        if (connection->fd_udp >= 0) {
+                epoll_ctl(connection->fd_epoll, EPOLL_CTL_DEL, connection->fd_udp, NULL);
+                connection->fd_udp = c_close(connection->fd_udp);
+        }
 
         r = n_dhcp4_c_socket_packet_new(&fd_packet, connection->client_config->ifindex);
         if (r)
@@ -990,13 +1002,13 @@ static int n_dhcp4_c_connection_send_request(NDhcp4CConnection *connection,
         case N_DHCP4_C_MESSAGE_DISCOVER:
         case N_DHCP4_C_MESSAGE_SELECT:
         case N_DHCP4_C_MESSAGE_REBOOT:
+        case N_DHCP4_C_MESSAGE_REBIND:
         case N_DHCP4_C_MESSAGE_DECLINE:
                 r = n_dhcp4_c_connection_packet_broadcast(connection, request);
                 if (r)
                         return r;
                 break;
         case N_DHCP4_C_MESSAGE_INFORM:
-        case N_DHCP4_C_MESSAGE_REBIND:
                 r = n_dhcp4_c_connection_udp_broadcast(connection, request);
                 if (r)
                         return r;

--- a/src/n-dhcp4-c-probe.c
+++ b/src/n-dhcp4-c-probe.c
@@ -726,6 +726,10 @@ static int n_dhcp4_client_probe_transition_t2(NDhcp4ClientProbe *probe, uint64_t
         switch (probe->state) {
         case N_DHCP4_CLIENT_PROBE_STATE_BOUND:
         case N_DHCP4_CLIENT_PROBE_STATE_RENEWING:
+                r = n_dhcp4_c_connection_listen(&probe->connection);
+                if (r)
+                        return r;
+
                 r = n_dhcp4_c_connection_rebind_new(&probe->connection, &request);
                 if (r)
                         return r;
@@ -846,11 +850,22 @@ static int n_dhcp4_client_probe_transition_offer(NDhcp4ClientProbe *probe, NDhcp
 static int n_dhcp4_client_probe_transition_ack(NDhcp4ClientProbe *probe, NDhcp4Incoming *message) {
         _c_cleanup_(n_dhcp4_client_lease_unrefp) NDhcp4ClientLease *lease = NULL;
         NDhcp4CEventNode *node;
+        struct in_addr client = {};
+        struct in_addr server = {};
         int r;
 
         switch (probe->state) {
-        case N_DHCP4_CLIENT_PROBE_STATE_RENEWING:
         case N_DHCP4_CLIENT_PROBE_STATE_REBINDING:
+                n_dhcp4_incoming_get_yiaddr(message, &client);
+
+                r = n_dhcp4_incoming_query_server_identifier(message, &server);
+                if (r)
+                        return r;
+                r = n_dhcp4_c_connection_connect(&probe->connection, &client, &server);
+                if (r)
+                        return r;
+                /* fall-through */
+        case N_DHCP4_CLIENT_PROBE_STATE_RENEWING:
 
                 r = n_dhcp4_client_probe_raise(probe,
                                                &node,

--- a/src/test-connection.c
+++ b/src/test-connection.c
@@ -358,13 +358,13 @@ static void test_connection(void) {
                 test_discover(&connection_server, &connection_client, &addr_server, &addr_client, &offer);
                 test_select(&connection_server, &connection_client, offer, &addr_server, &addr_client);
                 test_reboot(&connection_server, &connection_client, &addr_server, &addr_client, &ack);
+                test_rebind(&connection_server, &connection_client, &addr_server, &addr_client);
                 test_decline(&connection_server, &connection_client, ack);
 
                 link_add_ip4(&link_client, &addr_client, 8);
                 test_c_connection_connect(ns_client, &connection_client, &addr_client, &addr_server);
 
                 test_renew(&connection_server, &connection_client, &addr_server, &addr_client);
-                test_rebind(&connection_server, &connection_client, &addr_server, &addr_client);
                 test_release(&connection_server, &connection_client, &addr_server, &addr_client);
 
                 n_dhcp4_c_connection_deinit(&connection_client);


### PR DESCRIPTION
After t1, the client tries to renew the lease by contacting via the
udp socket the server specified in the server-id option. If this
fails, after t2 it tries to contact any server using broadcast. For
this to work, the packet socket must be used or reply packets from a
server different from the one specified in the server-id option will
be discarded.

Signed-off-by: Beniamino Galvani <bgalvani@redhat.com>