### PR TITLE
all: rework logging to append logging messages to the event queue

### DIFF
--- a/src/n-dhcp4-c-probe.c
+++ b/src/n-dhcp4-c-probe.c
@@ -429,9 +429,13 @@ int n_dhcp4_client_probe_new(NDhcp4ClientProbe **probep,
          */
         n_dhcp4_client_probe_config_initialize_random_seed(probe->config);
 
+        /* The new probe keeps a reference on @client. So we are sure that &client->log_queue
+         * stays alive as long as we need it. */
+
         r = n_dhcp4_c_connection_init(&probe->connection,
                                       client->config,
                                       probe->config,
+                                      &client->log_queue,
                                       active ? client->fd_epoll : -1);
         if (r)
                 return r;

--- a/src/n-dhcp4-private.h
+++ b/src/n-dhcp4-private.h
@@ -24,6 +24,7 @@ typedef struct NDhcp4Outgoing NDhcp4Outgoing;
 typedef struct NDhcp4SConnection NDhcp4SConnection;
 typedef struct NDhcp4SConnectionIp NDhcp4SConnectionIp;
 typedef struct NDhcp4SEventNode NDhcp4SEventNode;
+typedef struct NDhcp4LogQueue NDhcp4LogQueue;
 
 /* specs */
 
@@ -242,11 +243,6 @@ struct NDhcp4ClientConfig {
         size_t n_broadcast_mac;
         uint8_t *client_id;
         size_t n_client_id;
-        struct {
-                int level;
-                NDhcp4LogFunc func;
-                void *data;
-        } log;
 };
 
 #define N_DHCP4_CLIENT_CONFIG_NULL(_x) {                                        \
@@ -290,9 +286,42 @@ struct NDhcp4CEventNode {
                 .probe_link = C_LIST_INIT((_x).probe_link),                     \
         }
 
+struct NDhcp4LogQueue {
+        CList *event_list;
+        NDhcp4CEventNode nomem_node;
+        int log_level;
+        bool is_client : 1;
+};
+
+#define N_DHCP4_LOG_QUEUE_NULL_DEFUNCT() {                                      \
+                .log_level = -1,                                                \
+                .is_client = false,                                             \
+        }
+
+#define N_DHCP4_LOG_QUEUE_NULL_CLIENT(client) {                                 \
+                .event_list = &((client).event_list),                           \
+                .log_level = -1,                                                \
+                .is_client = true,                                              \
+                .nomem_node = {                                                 \
+                        .client_link = C_LIST_INIT((client).log_queue.nomem_node.client_link), \
+                        .probe_link = C_LIST_INIT((client).log_queue.nomem_node.probe_link), \
+                        .event = {                                              \
+                                .event = N_DHCP4_CLIENT_EVENT_LOG,              \
+                                .log = {                                        \
+                                        .level = LOG_CRIT,                      \
+                                        .message = "one or more logging messages dropped due to out of memory", \
+                                        .is_static_message = true,              \
+                                },                                              \
+                        },                                                      \
+                        .is_public = false,                                     \
+                },                                                              \
+        }
+
 struct NDhcp4CConnection {
         NDhcp4ClientConfig *client_config;
         NDhcp4ClientProbeConfig *probe_config;
+        NDhcp4LogQueue *log_queue;
+
         int fd_epoll;
 
         unsigned int state;             /* current connection state */
@@ -324,6 +353,9 @@ struct NDhcp4Client {
         unsigned long n_refs;
         NDhcp4ClientConfig *config;
         CList event_list;
+
+        NDhcp4LogQueue log_queue;
+
         int fd_epoll;
         int fd_timer;
 
@@ -339,6 +371,7 @@ struct NDhcp4Client {
                 .event_list = C_LIST_INIT((_x).event_list),                     \
                 .fd_epoll = -1,                                                 \
                 .fd_timer = -1,                                                 \
+                .log_queue = N_DHCP4_LOG_QUEUE_NULL_CLIENT(_x),                 \
         }
 
 struct NDhcp4ClientProbe {
@@ -570,6 +603,7 @@ NDhcp4CEventNode *n_dhcp4_c_event_node_free(NDhcp4CEventNode *node);
 int n_dhcp4_c_connection_init(NDhcp4CConnection *connection,
                               NDhcp4ClientConfig *client_config,
                               NDhcp4ClientProbeConfig *probe_config,
+                              NDhcp4LogQueue *log_queue,
                               int fd_epoll);
 void n_dhcp4_c_connection_deinit(NDhcp4CConnection *connection);
 
@@ -698,19 +732,28 @@ static inline uint64_t n_dhcp4_gettime(clockid_t clock) {
         return ts.tv_sec * 1000ULL * 1000ULL * 1000ULL + ts.tv_nsec;
 }
 
-#define n_dhcp4_c_log(_config, _level, ...)                                    \
+void n_dhcp4_log_queue_fmt(NDhcp4LogQueue *log_queue,
+                           int level,
+                           const char *fmt,
+                           ...) _c_printf_(3, 4);
+
+/**
+ * n_dhcp4_log() - append a logging event
+ * @x_log_queue:   the logging event queue
+ * @x_level:       the syslog logging level for the message.
+ * @...:           the format string and arguments.
+ *
+ * Warning: this macro only evaluates the format arguments if the logging
+ * level is enabled.
+ */
+#define n_dhcp4_log(x_log_queue, x_level, ...)                                 \
         do {                                                                   \
-                const NDhcp4ClientConfig *__config = _config;                  \
-                int __level = _level;                                          \
+                NDhcp4LogQueue *const _log_queue = (x_log_queue);              \
+                const int _level = (x_level);                                  \
                                                                                \
-                if (__level <= __config->log.level && __config->log.func) {    \
-                        if (1) {                                               \
-                                _config->log.func(__level,                     \
-                                                  __config->log.data,          \
-                                                  __VA_ARGS__);                \
-                        } else {                                               \
-                                /* To have the compiler check arguments */     \
-                                printf(__VA_ARGS__);                           \
-                        }                                                      \
+                if (_level <= _log_queue->log_level) {                         \
+                        n_dhcp4_log_queue_fmt(_log_queue,                      \
+                                              _level,                          \
+                                              __VA_ARGS__);                    \
                 }                                                              \
         } while (0)

--- a/src/n-dhcp4-private.h
+++ b/src/n-dhcp4-private.h
@@ -310,7 +310,7 @@ struct NDhcp4LogQueue {
                                 .log = {                                        \
                                         .level = LOG_CRIT,                      \
                                         .message = "one or more logging messages dropped due to out of memory", \
-                                        .is_static_message = true,              \
+                                        .allow_steal_message = false,           \
                                 },                                              \
                         },                                                      \
                         .is_public = false,                                     \

--- a/src/n-dhcp4.h
+++ b/src/n-dhcp4.h
@@ -88,12 +88,12 @@ struct NDhcp4ClientEvent {
                         NDhcp4ClientProbe *probe;
                 } retracted, expired, cancelled;
                 struct {
-                        /* If is_static_message is false, then the user may steal the message when handling
+                        /* If allow_steal_message is true, then the user may steal the message when handling
                          * the event. In that case, set the message field to %NULL and free it yourself
                          * with free(). */
                         const char *message;
                         int level;
-                        bool is_static_message;
+                        bool allow_steal_message;
                 } log;
         };
 };

--- a/src/n-dhcp4.h
+++ b/src/n-dhcp4.h
@@ -29,8 +29,6 @@ typedef struct NDhcp4ServerEvent NDhcp4ServerEvent;
 typedef struct NDhcp4ServerIp NDhcp4ServerIp;
 typedef struct NDhcp4ServerLease NDhcp4ServerLease;
 
-typedef void (*NDhcp4LogFunc)(int level, void *data, const char *fmt, ...);
-
 #define N_DHCP4_CLIENT_START_DELAY_RFC2131 (UINT64_C(9000))
 
 enum {
@@ -63,6 +61,7 @@ enum {
         N_DHCP4_CLIENT_EVENT_EXTENDED,
         N_DHCP4_CLIENT_EVENT_EXPIRED,
         N_DHCP4_CLIENT_EVENT_CANCELLED,
+        N_DHCP4_CLIENT_EVENT_LOG,
         _N_DHCP4_CLIENT_EVENT_N,
 };
 
@@ -88,6 +87,14 @@ struct NDhcp4ClientEvent {
                 struct {
                         NDhcp4ClientProbe *probe;
                 } retracted, expired, cancelled;
+                struct {
+                        /* If is_static_message is false, then the user may steal the message when handling
+                         * the event. In that case, set the message field to %NULL and free it yourself
+                         * with free(). */
+                        const char *message;
+                        int level;
+                        bool is_static_message;
+                } log;
         };
 };
 
@@ -113,8 +120,6 @@ void n_dhcp4_client_config_set_request_broadcast(NDhcp4ClientConfig *config, boo
 void n_dhcp4_client_config_set_mac(NDhcp4ClientConfig *config, const uint8_t *mac, size_t n_mac);
 void n_dhcp4_client_config_set_broadcast_mac(NDhcp4ClientConfig *config, const uint8_t *mac, size_t n_mac);
 int n_dhcp4_client_config_set_client_id(NDhcp4ClientConfig *config, const uint8_t *id, size_t n_id);
-void n_dhcp4_client_config_set_log_level(NDhcp4ClientConfig *config, int level);
-void n_dhcp4_client_config_set_log_func(NDhcp4ClientConfig *config, NDhcp4LogFunc func, void *data);
 
 /* client-probe configs */
 
@@ -140,6 +145,8 @@ NDhcp4Client *n_dhcp4_client_unref(NDhcp4Client *client);
 void n_dhcp4_client_get_fd(NDhcp4Client *client, int *fdp);
 int n_dhcp4_client_dispatch(NDhcp4Client *client);
 int n_dhcp4_client_pop_event(NDhcp4Client *client, NDhcp4ClientEvent **eventp);
+
+void n_dhcp4_client_set_log_level(NDhcp4Client *client, int level);
 
 int n_dhcp4_client_update_mtu(NDhcp4Client *client, uint16_t mtu);
 

--- a/src/test-connection.c
+++ b/src/test-connection.c
@@ -322,6 +322,7 @@ static void test_connection(void) {
                 NDhcp4CConnection connection_client = N_DHCP4_C_CONNECTION_NULL(connection_client);
                 _c_cleanup_(n_dhcp4_incoming_freep) NDhcp4Incoming *offer = NULL;
                 _c_cleanup_(n_dhcp4_incoming_freep) NDhcp4Incoming *ack = NULL;
+                NDhcp4LogQueue log_queue = N_DHCP4_LOG_QUEUE_NULL_DEFUNCT();
 
                 test_s_connection_init(ns_server, &connection_server, link_server.ifindex);
                 n_dhcp4_s_connection_ip_init(&connection_server_ip, addr_server);
@@ -351,6 +352,7 @@ static void test_connection(void) {
                 r = n_dhcp4_c_connection_init(&connection_client,
                                               client_config,
                                               probe_config,
+                                              &log_queue,
                                               efd_client);
                 c_assert(!r);
                 test_c_connection_listen(ns_client, &connection_client);


### PR DESCRIPTION
n-dhcp4 does not emit any events directly. Instead, during dispatch()
events get queued which the user then may pop afterwards.

The previous approach for logging used a callback function. This
function was invoked whenever something noteworthy happened (basically
during dispatcher()). That means, the logging messages were out of sync
with the events that otherwise get generated by n-dhcp4.

Rework the logging to instead queue logging events.

Currently logging is only implemented for NDhcp4Client.

---

follow-up for https://github.com/nettools/n-dhcp4/pull/8#issuecomment-630017648