### PR TITLE
n-dhcp4: fix BPF filter endianness issue

### DIFF
--- a/src/n-dhcp4-socket.c
+++ b/src/n-dhcp4-socket.c
@@ -50,8 +50,8 @@ int n_dhcp4_c_socket_packet_new(int *sockfdp, int ifindex) {
                 BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, IPPROTO_UDP, 1, 0),                                         /* IP protocol == UDP ? */
                 BPF_STMT(BPF_RET + BPF_K, 0),                                                                   /* ignore */
 
-                BPF_STMT(BPF_LD + BPF_B + BPF_ABS, offsetof(struct iphdr, frag_off)),                           /* A <- Flags */
-                BPF_STMT(BPF_ALU + BPF_AND + BPF_K, ntohs(IP_MF | IP_OFFMASK)),                                 /* A <- A & (IP_MF | IP_OFFMASK) */
+                BPF_STMT(BPF_LD + BPF_H + BPF_ABS, offsetof(struct iphdr, frag_off)),                           /* A <- Flags + Fragment offset */
+                BPF_STMT(BPF_ALU + BPF_AND + BPF_K, IP_MF | IP_OFFMASK),                                        /* A <- A & (IP_MF | IP_OFFMASK) */
                 BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, 0, 1, 0),                                                   /* fragmented packet ? */
                 BPF_STMT(BPF_RET + BPF_K, 0),                                                                   /* ignore */
 


### PR DESCRIPTION
The BPF filter takes the byte containing IP Flags and performs a
bitwise AND with "ntohs(IP_MF | IP_OFFMASK)".

On little-endian architectures the IP_MF flag (0x20) is ANDed with
0xFF3F and so the presence of the flag is correctly detected ignoring
other flags as IP_DF (0x40) or IP_RF (0x80).

On big-endian, "ntohs(IP_MF | IP_OFFMASK)" is 0x3FFF and so the filter
wrongly checks the presence of *any* flags. Therefore, a packet with
the DF flag set is dropped.

Instead, take the two bytes containing flags and offset and verify that IP_MF
and the offset are zero.

Fixes: 0cc5ffaac25f ("util/packet: add helpers for UDP emulation on top of AF_PACKET sockets")