### PR TITLE
[th/fix-lto-compiler-warnings]

### DIFF
--- a/src/util/packet.c
+++ b/src/util/packet.c
@@ -293,6 +293,8 @@ int packet_recvfrom_udp(int sockfd,
         ssize_t pktlen;
         size_t hdrlen;
 
+        *n_transmittedp = 0;
+
         /* Peek packet to obtain the real IP header length */
         pktlen = recv(sockfd, &ip_hdr.hdr, sizeof(ip_hdr.hdr), MSG_PEEK);
         if (pktlen < 0)
@@ -304,7 +306,6 @@ int packet_recvfrom_udp(int sockfd,
                  * discard it.
                  */
                 recv(sockfd, NULL, 0, 0);
-                *n_transmittedp = 0;
                 return 0;
         }
 
@@ -313,7 +314,6 @@ int packet_recvfrom_udp(int sockfd,
                  * This is not an IPv4 packet, discard it.
                  */
                 recv(sockfd, NULL, 0, 0);
-                *n_transmittedp = 0;
                 return 0;
         }
 
@@ -324,7 +324,6 @@ int packet_recvfrom_udp(int sockfd,
                  * header length, discard the packet.
                  */
                 recv(sockfd, NULL, 0, 0);
-                *n_transmittedp = 0;
                 return 0;
         }
 
@@ -354,7 +353,6 @@ int packet_recvfrom_udp(int sockfd,
                  * provided too small a buffer. In both cases, we simply drop
                  * the packet.
                  */
-                *n_transmittedp = 0;
                 return 0;
         }
 
@@ -366,14 +364,12 @@ int packet_recvfrom_udp(int sockfd,
                  * The packet is too small to even contain an entire UDP
                  * header, so discard it entirely.
                  */
-                *n_transmittedp = 0;
                 return 0;
         } else if ((size_t)pktlen < hdrlen + ntohs(udp_hdr.len)) {
                 /*
                  * The UDP header specified a longer length than the returned
                  * packet, so discard it entirely.
                  */
-                *n_transmittedp = 0;
                 return 0;
         }
 
@@ -386,13 +382,10 @@ int packet_recvfrom_udp(int sockfd,
         /* IP */
 
         if (ip_hdr.hdr.protocol != IPPROTO_UDP) {
-                *n_transmittedp = 0;
                 return 0; /* not a UDP packet, discard it */
         } else if (ip_hdr.hdr.frag_off & htons(IP_MF | IP_OFFMASK)) {
-                *n_transmittedp = 0;
                 return 0; /* fragmented packet, discard it */
         } else if (checksum && packet_internet_checksum(ip_hdr.data, hdrlen)) {
-                *n_transmittedp = 0;
                 return 0; /* invalid checksum, discard it */
         }
 
@@ -411,7 +404,6 @@ int packet_recvfrom_udp(int sockfd,
                                                 buf,
                                                 pktlen,
                                                 udp_hdr.check)) {
-                        *n_transmittedp = 0;
                         return 0;
                }
         }


### PR DESCRIPTION
On Fedora 32, with gcc-10.2.1-1.fc32 and

```
export CFLAGS='-flto -O3 -Werror -Wall -Wextra -Wno-unused-parameter'
git clean -fdx
meson build && ninja -C build

```

we get:

```
../src/n-dhcp4-c-connection.c: In function ‘n_dhcp4_c_connection_connect’:
../src/n-dhcp4-c-connection.c:196:13: error: ‘fd_udp’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  196 |         r = epoll_ctl(connection->fd_epoll,
      |             ^
../src/n-dhcp4-c-connection.c:185:16: note: ‘fd_udp’ was declared here
  185 |         int r, fd_udp;
      |                ^

../src/n-dhcp4-socket.c: In function ‘n_dhcp4_c_socket_packet_recv.constprop’:
../src/n-dhcp4-incoming.c:210:29: error: ‘len’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  210 |         incoming->n_message = n_raw;
      |                             ^
../src/n-dhcp4-socket.c:558:16: note: ‘len’ was declared here
  558 |         size_t len;
      |                ^

```

Work around.
