### PR TITLE
client-lease: add n_dhcp4_client_lease_get_server_identifier()

### DIFF
--- a/src/libndhcp4.sym
+++ b/src/libndhcp4.sym
@@ -36,6 +36,7 @@ global:
         n_dhcp4_client_lease_get_yiaddr;
         n_dhcp4_client_lease_get_siaddr;
         n_dhcp4_client_lease_get_lifetime;
+        n_dhcp4_client_lease_get_server_identifier;
         n_dhcp4_client_lease_query;
         n_dhcp4_client_lease_select;
         n_dhcp4_client_lease_accept;

--- a/src/n-dhcp4-c-lease.c
+++ b/src/n-dhcp4-c-lease.c
@@ -242,6 +242,32 @@ _c_public_ void n_dhcp4_client_lease_get_lifetime(NDhcp4ClientLease *lease, uint
 }
 
 /**
+ * n_dhcp4_client_lease_get_server_identifier() - get the server identifier
+ * @lease:                      the lease to operate on
+ * @addr:                       return argument for the server identifier
+ *
+ * Gets the address contained in the server-identifier DHCP option, in network
+ * byte order.
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+_c_public_ int n_dhcp4_client_lease_get_server_identifier (NDhcp4ClientLease *lease, struct in_addr *addr) {
+        uint8_t *data;
+        size_t n_data;
+        int r;
+
+        r = n_dhcp4_incoming_query(lease->message, N_DHCP4_OPTION_SERVER_IDENTIFIER, &data, &n_data);
+        if (r)
+                return r;
+        if (n_data < sizeof(struct in_addr))
+                return N_DHCP4_E_MALFORMED;
+
+        memcpy(addr, data, sizeof(struct in_addr));
+
+        return 0;
+}
+
+/**
  * n_dhcp4_client_lease_query() - query the lease for an option
  * @lease:                      the lease to operate on
  * @option:                     the DHCP4 option code

--- a/src/n-dhcp4.h
+++ b/src/n-dhcp4.h
@@ -171,6 +171,7 @@ void n_dhcp4_client_lease_get_siaddr(NDhcp4ClientLease *lease, struct in_addr *s
 void n_dhcp4_client_lease_get_basetime(NDhcp4ClientLease *lease, uint64_t *ns_basetimep);
 void n_dhcp4_client_lease_get_lifetime(NDhcp4ClientLease *lease, uint64_t *ns_lifetimep);
 int n_dhcp4_client_lease_query(NDhcp4ClientLease *lease, uint8_t option, uint8_t **datap, size_t *n_datap);
+int n_dhcp4_client_lease_get_server_identifier (NDhcp4ClientLease *lease, struct in_addr *addr);
 
 int n_dhcp4_client_lease_select(NDhcp4ClientLease *lease);
 int n_dhcp4_client_lease_accept(NDhcp4ClientLease *lease);

--- a/src/test-api.c
+++ b/src/test-api.c
@@ -106,6 +106,7 @@ static void test_api_functions(void) {
                 (void *)n_dhcp4_client_lease_get_yiaddr,
                 (void *)n_dhcp4_client_lease_get_siaddr,
                 (void *)n_dhcp4_client_lease_get_lifetime,
+                (void *)n_dhcp4_client_lease_get_server_identifier,
                 (void *)n_dhcp4_client_lease_query,
                 (void *)n_dhcp4_client_lease_select,
                 (void *)n_dhcp4_client_lease_accept,


### PR DESCRIPTION
Add new API to query the server identifier of a lease.

Signed-off-by: Beniamino Galvani <bgalvani@redhat.com>