### PR TITLE
socket: work around compiler warning in n_dhcp4_socket_packet_send()

### DIFF
--- a/src/util/packet.c
+++ b/src/util/packet.c
@@ -223,7 +223,7 @@ int packet_sendto_udp(int sockfd,
 
         pktlen = sendmsg(sockfd, &msg, 0);
         if (pktlen < 0)
-                return -errno;
+                return -c_errno();
 
         /*
          * Kernel never truncates. Worst case, we get -EMSGSIZE. Kernel *might*


### PR DESCRIPTION
With LTO enabled, the compiler might think that "len" is not initialized.
That is even a correct assumption, if the compiler does not understand the
API of sendmsg() and that sendmsg() is supposed to set a negative errno.

Work around by initializing the variable.
```
    shared/n-dhcp4/src/n-dhcp4-c-connection.c: In function n_dhcp4_c_connection_send_request:
    shared/n-dhcp4/src/n-dhcp4-socket.c:368:19: error: len may be used uninitialized in this function [-Werror=maybe-uninitialized]
             } else if (len != n_buf) {
                       ^
    shared/n-dhcp4/src/n-dhcp4-socket.c:351:23: note: len was declared here
             size_t n_buf, len;
                           ^
```
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/4686e9baef85037b72e0a69546a6c48f31d5b91e