### PR TITLE
connection: avoid maybe-uninitialized warning in n_dhcp4_c_connection_dispatch_io()

### DIFF
--- a/src/n-dhcp4-c-connection.c
+++ b/src/n-dhcp4-c-connection.c
@@ -1148,7 +1148,7 @@ int n_dhcp4_c_connection_dispatch_io(NDhcp4CConnection *connection,
         _c_cleanup_(n_dhcp4_incoming_freep) NDhcp4Incoming *message = NULL;
         char serv_addr[INET_ADDRSTRLEN];
         char client_addr[INET_ADDRSTRLEN];
-        uint8_t type;
+        uint8_t type = 0;
         int r;
 
         switch (connection->state) {


### PR DESCRIPTION
On RHEL-8.5, s390x with gcc-8.5.0-2.el8, we get a compiler warning:
```
  $ CFLAGS='-O2 -Werror=maybe-uninitialized' meson build
  ...
  cc -Isrc/libndhcp4-private.a.p -Isrc -I../src -Isubprojects/c-list/src -I../subprojects/c-list/src -Isubprojects/c-siphash/src -I../subprojects/c-siphash/src -Isubprojects/c-stdaux/src -I../subprojects/c-stdaux/src -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c11 -g -D_GNU_SOURCE -O2 -Werror=maybe-uninitialized -fPIC -fvisibility=hidden -fno-common -MD -MQ src/libndhcp4-private.a.p/n-dhcp4-c-connection.c.o -MF src/libndhcp4-private.a.p/n-dhcp4-c-connection.c.o.d -o src/libndhcp4-private.a.p/n-dhcp4-c-connection.c.o -c ../src/n-dhcp4-c-connection.c
  ../src/n-dhcp4-c-connection.c: In function ‘n_dhcp4_c_connection_dispatch_io’:
  ../src/n-dhcp4-c-connection.c:1151:17: error: ‘type’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
           uint8_t type;
                   ^~~~
```