### PR TITLE
connection: use global thread-local scratch buffer

### DIFF
--- a/src/n-dhcp4-c-connection.c
+++ b/src/n-dhcp4-c-connection.c
@@ -1146,16 +1146,21 @@ int n_dhcp4_c_connection_dispatch_timer(NDhcp4CConnection *connection,
 int n_dhcp4_c_connection_dispatch_io(NDhcp4CConnection *connection,
                                      NDhcp4Incoming **messagep) {
         _c_cleanup_(n_dhcp4_incoming_freep) NDhcp4Incoming *message = NULL;
+        _c_cleanup_(c_freep) uint8_t *buffer = NULL;
         char serv_addr[INET_ADDRSTRLEN];
         char client_addr[INET_ADDRSTRLEN];
         uint8_t type = 0;
         int r;
 
+        buffer = malloc(UINT16_MAX);
+        if (!buffer)
+                return -ENOMEM;
+
         switch (connection->state) {
         case N_DHCP4_C_CONNECTION_STATE_PACKET:
                 r = n_dhcp4_c_socket_packet_recv(connection->fd_packet,
-                                                 connection->scratch_buffer,
-                                                 sizeof(connection->scratch_buffer),
+                                                 buffer,
+                                                 UINT16_MAX,
                                                  &message);
                 if (!r)
                         break;
@@ -1164,8 +1169,8 @@ int n_dhcp4_c_connection_dispatch_io(NDhcp4CConnection *connection,
                 return N_DHCP4_E_AGAIN;
         case N_DHCP4_C_CONNECTION_STATE_DRAINING:
                 r = n_dhcp4_c_socket_packet_recv(connection->fd_packet,
-                                                 connection->scratch_buffer,
-                                                 sizeof(connection->scratch_buffer),
+                                                 buffer,
+                                                 UINT16_MAX,
                                                  &message);
                 if (!r)
                         break;
@@ -1187,8 +1192,8 @@ int n_dhcp4_c_connection_dispatch_io(NDhcp4CConnection *connection,
                 /* fall-through */
         case N_DHCP4_C_CONNECTION_STATE_UDP:
                 r = n_dhcp4_c_socket_udp_recv(connection->fd_udp,
-                                              connection->scratch_buffer,
-                                              sizeof(connection->scratch_buffer),
+                                              buffer,
+                                              UINT16_MAX,
                                               &message);
                 if (!r)
                         break;

--- a/src/n-dhcp4-private.h
+++ b/src/n-dhcp4-private.h
@@ -333,15 +333,6 @@ struct NDhcp4CConnection {
         uint32_t client_ip;             /* client IP address, or 0 */
         uint32_t server_ip;             /* server IP address, or 0 */
         uint16_t mtu;                   /* client mtu, or 0 */
-
-        /*
-         * When we get DHCP packets from the kernel, we need a buffer to read
-         * the data into. Since UDP packets can be up to 2^16 bytes in size, we
-         * avoid placing it on the stack and instead read into this scratch
-         * buffer. It is purely meant as stack replacement, no data is returned
-         * through this buffer.
-         */
-        uint8_t scratch_buffer[UINT16_MAX];
 };
 
 #define N_DHCP4_C_CONNECTION_NULL(_x) {                                         \


### PR DESCRIPTION
NOTE: this uses the `c_thread_local` macro from https://github.com/c-util/c-stdaux/pull/7, not yet merged.

Each connection object includes a 64KiB scratch buffer used for receiving packets. When many instances of the client are created, those buffers use a significant amount of memory. Since they are only used in n_dhcp4_c_connection_dispatch_io(), replace them with a static global buffer. To support multiple threads, make that buffer thread-local.

https://github.com/nettools/n-dhcp4/issues/26