### PR TITLE
connection: discard NAKs from other servers in SELECTING

### DIFF
--- a/src/n-dhcp4-private.h
+++ b/src/n-dhcp4-private.h
@@ -202,6 +202,7 @@ struct NDhcp4Outgoing {
                 uint8_t type;
                 uint8_t message_type;
                 uint32_t client_addr;
+                uint32_t server_id;
                 uint64_t start_time;
                 uint64_t base_time;
                 uint64_t send_time;


### PR DESCRIPTION
I got a report of a scenario where multiple servers reply to a REQUEST
in SELECTING, and all servers send NAKs except the one which sent the
offer, which replies with a ACK. In that scenario, n-dhcp4 is not able
to obtain a lease because it restarts from INIT as soon as the first
NAK is received. For comparison, dhclient can get a lease because it
ignores all NAKs in SELECTING.

Arguably, the network is misconfigured there, but it would be great if
n-dhcp4 could still work in such scenario.

According to RFC 2131, ACK and NAK messages from server must contain a
server-id option. The RFC doesn't explicitly say that the client
should check the option, but I think it's a reasonable thing to do, at
least for NAKs.

This patch stores the server-id of the REQUEST in SELECTING, and
compares it with the server-id from NAKs, to discard other servers'
replies.