### PR TITLE
connection: drop DRAINING state

### DIFF
--- a/src/n-dhcp4-private.h
+++ b/src/n-dhcp4-private.h
@@ -331,6 +331,7 @@ struct NDhcp4CConnection {
 
         NDhcp4Outgoing *request;        /* current request */
 
+        uint64_t ns_drain_timeout;      /* timeout for closing packet socket */
         uint32_t client_ip;             /* client IP address, or 0 */
         uint32_t server_ip;             /* server IP address, or 0 */
         uint16_t mtu;                   /* client mtu, or 0 */


### PR DESCRIPTION
@dvdhrm, @teg, what do you think about this? We got a report on https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/974 that the packet socket is kept open until the first renew.

--

After the connection creates the UDP socket, it enters the DRAINING state and and a BPF filter gets attached to the socket to prevent new packets from being queued. The purpose of the state is to allow the packets already queued to be processed.

At the next received packet (from any of the two sockets) the packet socket gets drained and closed.

The problem with this approach is that when no packet is queued on the packet socket, the socket stays alive until T1, when the client tries to renew the address. I think having an extra socket open unnecessarily, albeit dropping all packets via BPF, should be avoided.

Note that when a UDP connection exists (after receiving an ACK), any other message queued from the packet socket can be discarded.

Therefore, remove the DRAINING connection state and close the packet socket immediately.