### PR TITLE
probe: forget lease after a NAK

### DIFF
--- a/src/n-dhcp4-c-probe.c
+++ b/src/n-dhcp4-c-probe.c
@@ -995,14 +995,13 @@ static int n_dhcp4_client_probe_transition_nak(NDhcp4ClientProbe *probe) {
         case N_DHCP4_CLIENT_PROBE_STATE_RENEWING:
         case N_DHCP4_CLIENT_PROBE_STATE_REBINDING:
 
-                /* XXX */
-
                 r = n_dhcp4_client_probe_raise(probe,
                                                NULL,
                                                N_DHCP4_CLIENT_EVENT_RETRACTED);
                 if (r)
                         return r;
 
+                probe->current_lease = n_dhcp4_client_lease_unref(probe->current_lease);
                 probe->state = N_DHCP4_CLIENT_PROBE_STATE_INIT;
                 probe->ns_deferred = n_dhcp4_gettime(CLOCK_BOOTTIME) + probe->ns_nak_restart_delay;
                 probe->ns_nak_restart_delay = C_CLAMP(probe->ns_nak_restart_delay * 2u,


### PR DESCRIPTION
If we have a lease and we get a NAK renewing/rebinding it, the lease is lost.

Without this, probe->current_lease remains set and after the next DISCOVER/OFFER round, any call to `n_dhcp4_client_lease_select()` will fail at:

        if (lease->probe->current_lease)
                return -ENOTRECOVERABLE;

as in:

    [5325.1313] dhcp4 (veth0): send REQUEST of 172.25.1.200 to 255.255.255.255
    [5325.1434] dhcp4 (veth0): received NACK from 172.25.1.1
    [5325.1435] dhcp4 (veth0): client event 3 (RETRACTED)
    [5325.1436] dhcp4 (veth0): send DISCOVER to 255.255.255.255
    [5325.1641] dhcp4 (veth0): received OFFER of 172.25.1.200 from 172.25.1.1
    [5325.1641] dhcp4 (veth0): client event (OFFER)
    [5325.1641] dhcp4 (veth0): selecting lease failed: -131 (ENOTRECOVERABLE)