### PR TITLE
n-dhcp4-client: check broadcast_mac field in n_dhcp4_client_config_set_broadcast_mac()

### DIFF
--- a/src/n-dhcp4-client.c
+++ b/src/n-dhcp4-client.c
@@ -214,8 +214,8 @@ _c_public_ void n_dhcp4_client_config_set_mac(NDhcp4ClientConfig *config, const 
 _c_public_ void n_dhcp4_client_config_set_broadcast_mac(NDhcp4ClientConfig *config, const uint8_t *mac, size_t n_mac) {
         config->n_broadcast_mac = n_mac;
 
-        if (n_mac > sizeof(config->mac))
-                n_mac = sizeof(config->mac);
+        if (n_mac > sizeof(config->broadcast_mac))
+                n_mac = sizeof(config->broadcast_mac);
 
         memcpy(config->broadcast_mac, mac, n_mac);
 }


### PR DESCRIPTION
Since the "mac" and "broadcast_mac" fields have the same size, there
was no actual bug here. Still, it feels more correct.

---

[trivial]