### PR TITLE
meson: no longer pass -Wl,--no-undefined explicitly

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -44,7 +44,6 @@ libndhcp4_shared = shared_library(
         soversion: 0,
         link_depends: libndhcp4_symfile,
         link_args: [
-                '-Wl,--no-undefined',
                 '-Wl,--version-script=@0@'.format(libndhcp4_symfile)
         ],
 )


### PR DESCRIPTION
to make it possible to build n-dhcp4 with clang and ASan.

-Wl,--no-undefined is still passed by meson by default unless -Db_lundef is set to false explictily:
https://github.com/mesonbuild/meson/issues/764

To get it to work the c-siphash submodule has to be bumped to at least https://github.com/c-util/c-siphash/commit/203347c4d3e42de0561f0017c4015e996ba20fdb as well but it should probably be delayed until the next release or something like that.