### PR TITLE
n-dhcp4-client: make n_dhcp4_client_set_log_level public

### DIFF
--- a/src/libndhcp4.sym
+++ b/src/libndhcp4.sym
@@ -26,6 +26,7 @@ global:
         n_dhcp4_client_pop_event;
         n_dhcp4_client_update_mtu;
         n_dhcp4_client_probe;
+        n_dhcp4_client_set_log_level;
 
         n_dhcp4_client_probe_free;
         n_dhcp4_client_probe_get_userdata;


### PR DESCRIPTION
It is already declared public but was not present in the symbol file, making unavailable for external program linked to libndhcp4.