### PR TITLE
test: use inet_pton() instead of inet_aton() in test tool

### DIFF
--- a/src/test-run-client.c
+++ b/src/test-run-client.c
@@ -597,7 +597,7 @@ static int parse_argv(int argc, char **argv) {
                         break;
 
                 case ARG_REQUESTED_IP:
-                        r = inet_aton(optarg, &main_arg_requested_ip);
+                        r = inet_pton(AF_INET, optarg, &main_arg_requested_ip);
                         if (r != 1) {
                                 fprintf(stderr,
                                         "%s: invalid requested IP -- '%s'\n",


### PR DESCRIPTION
inet_aton() accepts questionable input as IPv4 address, like fewer than 4 digits or trailing garbage.
```
  ./build/src/test-run-client --requested-ip '2.4.5.6 dd'
  ./build/src/test-run-client --requested-ip '2.4.5'
  ./build/src/test-run-client --requested-ip '2'
  ./build/src/test-run-client --requested-ip '02.4.5'
  ./build/src/test-run-client --requested-ip '0x2.4.5'
```
Also, the ABI checker in RHEL complains when using it. Sure, this is only a test tool. But lets not use it.