### PR TITLE
Change the default DSCP value of the IP header to 0, and allow setting a custom value

### DIFF
--- a/src/n-dhcp4-c-connection.c
+++ b/src/n-dhcp4-c-connection.c
@@ -191,7 +191,8 @@ int n_dhcp4_c_connection_connect(NDhcp4CConnection *connection,
         r = n_dhcp4_c_socket_udp_new(&fd_udp,
                                      connection->client_config->ifindex,
                                      client,
-                                     server);
+                                     server,
+                                     connection->probe_config->dscp);
         if (r)
                 return r;
 
@@ -388,6 +389,7 @@ static int n_dhcp4_c_connection_packet_broadcast(NDhcp4CConnection *connection,
                                          connection->client_config->ifindex,
                                          connection->client_config->broadcast_mac,
                                          connection->client_config->n_broadcast_mac,
+                                         connection->probe_config->dscp,
                                          message);
         if (r)
                 return r;

--- a/src/n-dhcp4-c-probe.c
+++ b/src/n-dhcp4-c-probe.c
@@ -198,7 +198,7 @@ _c_public_ void n_dhcp4_client_probe_config_set_init_reboot(NDhcp4ClientProbeCon
  *
  * This sets the DSCP property of the configuration object, which specifies
  * the DSCP value to set in the first six bits of the DS field in the IPv4
- * header. If this function is not called, the DSCP will be set to CS6.
+ * header. If this function is not called, the DSCP will be set to CS0 (0).
  */
 _c_public_ void n_dhcp4_client_probe_config_set_dscp(NDhcp4ClientProbeConfig *config, uint8_t dscp) {
         config->dscp = dscp & 0x3F;

--- a/src/n-dhcp4-c-probe.c
+++ b/src/n-dhcp4-c-probe.c
@@ -118,6 +118,7 @@ int n_dhcp4_client_probe_config_dup(NDhcp4ClientProbeConfig *config,
         dup->init_reboot = config->init_reboot;
         dup->requested_ip = config->requested_ip;
         dup->ms_start_delay = config->ms_start_delay;
+        dup->dscp = config->dscp;
 
         for (unsigned int i = 0; i < config->n_request_parameters; ++i)
                 dup->request_parameters[dup->n_request_parameters++] = config->request_parameters[i];
@@ -188,6 +189,19 @@ _c_public_ void n_dhcp4_client_probe_config_set_inform_only(NDhcp4ClientProbeCon
  */
 _c_public_ void n_dhcp4_client_probe_config_set_init_reboot(NDhcp4ClientProbeConfig *config, bool init_reboot) {
         config->init_reboot = init_reboot;
+}
+
+/**
+ * n_dhcp4_client_probe_config_set_dscp() - set the IP DSCP value
+ * @config:                     configuration to operate on
+ * @dscp:                       value to set
+ *
+ * This sets the DSCP property of the configuration object, which specifies
+ * the DSCP value to set in the first six bits of the DS field in the IPv4
+ * header. If this function is not called, the DSCP will be set to CS6.
+ */
+_c_public_ void n_dhcp4_client_probe_config_set_dscp(NDhcp4ClientProbeConfig *config, uint8_t dscp) {
+        config->dscp = dscp & 0x3F;
 }
 
 /**

--- a/src/n-dhcp4-private.h
+++ b/src/n-dhcp4-private.h
@@ -7,6 +7,7 @@
 #include <endian.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <netinet/ip.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <time.h>
@@ -34,6 +35,7 @@ typedef struct NDhcp4LogQueue NDhcp4LogQueue;
 #define N_DHCP4_NETWORK_CLIENT_PORT (68)
 #define N_DHCP4_MESSAGE_MAGIC ((uint32_t)(0x63825363))
 #define N_DHCP4_MESSAGE_FLAG_BROADCAST (htons(0x8000))
+#define N_DHCP4_DSCP_DEFAULT (IPTOS_CLASS_CS6 >> 2)
 
 enum {
         N_DHCP4_OP_BOOTREQUEST                          = 1,
@@ -263,6 +265,7 @@ struct NDhcp4ClientProbeOption {
 struct NDhcp4ClientProbeConfig {
         bool inform_only;
         bool init_reboot;
+        uint8_t dscp;
         struct in_addr requested_ip;
         unsigned short int entropy[3];
         uint64_t ms_start_delay;        /* max ms to wait before starting probe */
@@ -273,6 +276,7 @@ struct NDhcp4ClientProbeConfig {
 
 #define N_DHCP4_CLIENT_PROBE_CONFIG_NULL(_x) {                                  \
                 .ms_start_delay = N_DHCP4_CLIENT_START_DELAY_RFC2131,           \
+                .dscp = N_DHCP4_DSCP_DEFAULT,                                   \
         }
 
 struct NDhcp4CEventNode {
@@ -536,7 +540,8 @@ int n_dhcp4_c_socket_packet_new(int *sockfdp, int ifindex);
 int n_dhcp4_c_socket_udp_new(int *sockfdp,
                              int ifindex,
                              const struct in_addr *client_addr,
-                             const struct in_addr *server_addr);
+                             const struct in_addr *server_addr,
+                             uint8_t dscp);
 int n_dhcp4_s_socket_packet_new(int *sockfdp);
 int n_dhcp4_s_socket_udp_new(int *sockfdp, int ifindex);
 
@@ -544,6 +549,7 @@ int n_dhcp4_c_socket_packet_send(int sockfd,
                                  int ifindex,
                                  const unsigned char *dest_haddr,
                                  unsigned char halen,
+                                 uint8_t dscp,
                                  NDhcp4Outgoing *message);
 int n_dhcp4_c_socket_udp_send(int sockfd, NDhcp4Outgoing *message);
 int n_dhcp4_c_socket_udp_broadcast(int sockfd, NDhcp4Outgoing *message);
@@ -553,6 +559,7 @@ int n_dhcp4_s_socket_packet_send(int sockfd,
                                  const unsigned char *dest_haddr,
                                  unsigned char halen,
                                  const struct in_addr *dest_inaddr,
+                                 uint8_t dscp,
                                  NDhcp4Outgoing *message);
 int n_dhcp4_s_socket_udp_send(int sockfd,
                               const struct in_addr *inaddr_src,

--- a/src/n-dhcp4-private.h
+++ b/src/n-dhcp4-private.h
@@ -35,7 +35,7 @@ typedef struct NDhcp4LogQueue NDhcp4LogQueue;
 #define N_DHCP4_NETWORK_CLIENT_PORT (68)
 #define N_DHCP4_MESSAGE_MAGIC ((uint32_t)(0x63825363))
 #define N_DHCP4_MESSAGE_FLAG_BROADCAST (htons(0x8000))
-#define N_DHCP4_DSCP_DEFAULT (IPTOS_CLASS_CS6 >> 2)
+#define N_DHCP4_DSCP_DEFAULT (IPTOS_CLASS_CS0 >> 2)
 
 enum {
         N_DHCP4_OP_BOOTREQUEST                          = 1,

--- a/src/n-dhcp4-s-connection.c
+++ b/src/n-dhcp4-s-connection.c
@@ -202,6 +202,7 @@ int n_dhcp4_s_connection_send_reply(NDhcp4SConnection *connection,
                                                  header->chaddr,
                                                  header->hlen,
                                                  &(struct in_addr){header->yiaddr},
+                                                 N_DHCP4_DSCP_DEFAULT,
                                                  message);
                 if (r)
                         return r;

--- a/src/n-dhcp4.h
+++ b/src/n-dhcp4.h
@@ -128,6 +128,7 @@ NDhcp4ClientProbeConfig *n_dhcp4_client_probe_config_free(NDhcp4ClientProbeConfi
 
 void n_dhcp4_client_probe_config_set_inform_only(NDhcp4ClientProbeConfig *config, bool inform_only);
 void n_dhcp4_client_probe_config_set_init_reboot(NDhcp4ClientProbeConfig *config, bool init_reboot);
+void n_dhcp4_client_probe_config_set_dscp(NDhcp4ClientProbeConfig *config, uint8_t dscp);
 void n_dhcp4_client_probe_config_set_requested_ip(NDhcp4ClientProbeConfig *config, struct in_addr ip);
 void n_dhcp4_client_probe_config_set_start_delay(NDhcp4ClientProbeConfig *config, uint64_t msecs);
 void n_dhcp4_client_probe_config_request_option(NDhcp4ClientProbeConfig *config, uint8_t option);

--- a/src/test-socket.c
+++ b/src/test-socket.c
@@ -46,7 +46,7 @@ static void test_client_udp_socket_new(Link *link,
         netns_get(&oldns);
         netns_set(link->netns);
 
-        r = n_dhcp4_c_socket_udp_new(skp, link->ifindex, addr_client, addr_server);
+        r = n_dhcp4_c_socket_udp_new(skp, link->ifindex, addr_client, addr_server, N_DHCP4_DSCP_DEFAULT);
         c_assert(r >= 0);
 
         netns_set(oldns);
@@ -95,6 +95,7 @@ static void test_client_server_packet(Link *link_server, Link *link_client) {
                                          link_client->ifindex,
                                          (const unsigned char[]){0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
                                          ETH_ALEN,
+                                         -1,
                                          outgoing);
         c_assert(!r);
 
@@ -178,6 +179,7 @@ static void test_server_client_packet(Link *link_server, Link *link_client) {
                                          link_client->mac.ether_addr_octet,
                                          ETH_ALEN,
                                          &addr_client,
+                                         N_DHCP4_DSCP_DEFAULT,
                                          outgoing);
         c_assert(!r);
         r = n_dhcp4_s_socket_packet_send(sk_server,
@@ -188,6 +190,7 @@ static void test_server_client_packet(Link *link_server, Link *link_client) {
                                          },
                                          ETH_ALEN,
                                          &addr_client,
+                                         N_DHCP4_DSCP_DEFAULT,
                                          outgoing);
         c_assert(!r);
 

--- a/src/util/packet.c
+++ b/src/util/packet.c
@@ -150,6 +150,7 @@ uint16_t packet_internet_checksum_udp(const struct in_addr *src_addr,
  * @src_paddr:          source protocol address, see ip(7)
  * @dest_haddr:         destination hardware address, see packet(7)
  * @dest_paddr:         destination protocol address, see ip(7)
+ * @dscp:               the DSCP value
  *
  * Sends an UDP packet on a AF_PACKET socket directly to a hardware
  * address. The difference between this and sendto() on an AF_INET
@@ -165,11 +166,12 @@ int packet_sendto_udp(int sockfd,
                       size_t *n_transmittedp,
                       const struct sockaddr_in *src_paddr,
                       const struct packet_sockaddr_ll *dest_haddr,
-                      const struct sockaddr_in *dest_paddr) {
+                      const struct sockaddr_in *dest_paddr,
+                      uint8_t dscp) {
         struct iphdr ip_hdr = {
                 .version = IPVERSION,
                 .ihl = sizeof(ip_hdr) / 4, /* Length of header in multiples of four bytes */
-                .tos = IPTOS_CLASS_CS6, /* Class Selector for network control */
+                .tos = dscp << 2,
                 .tot_len = htons(sizeof(struct iphdr) + sizeof(struct udphdr) + n_buf),
                 .frag_off = htons(IP_DF), /* Do not fragment */
                 .ttl = IPDEFTTL,

--- a/src/util/packet.h
+++ b/src/util/packet.h
@@ -42,7 +42,8 @@ int packet_sendto_udp(int sockfd,
                       size_t *n_transmittedp,
                       const struct sockaddr_in *src_paddr,
                       const struct packet_sockaddr_ll *dest_haddr,
-                      const struct sockaddr_in *dest_paddr);
+                      const struct sockaddr_in *dest_paddr,
+                      uint8_t dscp);
 int packet_recvfrom_udp(int sockfd,
                         void *buf,
                         size_t n_buf,

--- a/src/util/test-packet.c
+++ b/src/util/test-packet.c
@@ -123,7 +123,7 @@ static void test_packet_unicast(int ifindex, int sk, void *buf, size_t n_buf,
 
         memcpy(addr.sll_addr, haddr_dst, ETH_ALEN);
 
-        r = packet_sendto_udp(sk, buf, n_buf, &len, paddr_src, &addr, paddr_dst);
+        r = packet_sendto_udp(sk, buf, n_buf, &len, paddr_src, &addr, paddr_dst, N_DHCP4_DSCP_DEFAULT);
         c_assert(!r);
         c_assert(len == n_buf);
 }
@@ -142,7 +142,7 @@ static void test_packet_broadcast(int ifindex, int sk, void *buf, size_t n_buf,
 
         memcpy(addr.sll_addr, (unsigned char[]){ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, }, ETH_ALEN);
 
-        r = packet_sendto_udp(sk, buf, n_buf, &len, paddr_src, &addr, paddr_dst);
+        r = packet_sendto_udp(sk, buf, n_buf, &len, paddr_src, &addr, paddr_dst, N_DHCP4_DSCP_DEFAULT);
         c_assert(!r);
         c_assert(len == n_buf);
 }


### PR DESCRIPTION
Section 4.9 of RFC 4594 specifies that DHCP should use the standard (CS0 = 0) service class. Section 3.2 says that class CS6 is for "transmitting packets between network devices (routers) that require control (routing) information to be exchanged between nodes", listing "OSPF, BGP, ISIS, RIP" as examples of such traffic. Furthermore, it says that:

        User traffic is not allowed to use this service class.  By user
        traffic, we mean packet flows that originate from user-controlled
        end points that are connected to the network.

Indeed, we got reports of some Cisco switches dropping DHCP packets because of the CS6 marking.

For these reasons, change the default value to the recommended one, CS0.

Also, allow changing the DSCP used by the client.

