### PR TITLE
n-dhcp4: set xid of the DHCP header for RELEASE and DECLINE message

### DIFF
--- a/src/n-dhcp4-c-connection.c
+++ b/src/n-dhcp4-c-connection.c
@@ -1027,13 +1027,13 @@ static int n_dhcp4_c_connection_send_request(NDhcp4CConnection *connection,
         case N_DHCP4_C_MESSAGE_REBOOT:
         case N_DHCP4_C_MESSAGE_REBIND:
         case N_DHCP4_C_MESSAGE_RENEW:
+        case N_DHCP4_C_MESSAGE_DECLINE:
+        case N_DHCP4_C_MESSAGE_RELEASE:
                 request->userdata.base_time = timestamp;
                 n_dhcp4_outgoing_set_xid(request, n_dhcp4_client_probe_config_get_random(connection->probe_config));
 
                 break;
         case N_DHCP4_C_MESSAGE_SELECT:
-        case N_DHCP4_C_MESSAGE_DECLINE:
-        case N_DHCP4_C_MESSAGE_RELEASE:
                 break;
         default:
                 c_assert(0);


### PR DESCRIPTION
The `xid` of the DHCP header must be initialized for RELEASE and DECLINE messages [1].

[1] https://datatracker.ietf.org/doc/html/rfc2131#section-4.4.1