### PR TITLE
n-dhcp4: Do not set ciaddr in DISCOVER state.

### DIFF
--- a/src/n-dhcp4-c-connection.c
+++ b/src/n-dhcp4-c-connection.c
@@ -379,6 +379,10 @@ void n_dhcp4_c_connection_get_timeout(NDhcp4CConnection *connection,
         *timeoutp = timeout;
 }
 
+void n_dhcp4_c_connection_clear_client_ip(NDhcp4CConnection *connection) {
+        connection->client_ip = INADDR_ANY;
+}
+
 static int n_dhcp4_c_connection_packet_broadcast(NDhcp4CConnection *connection,
                                                  NDhcp4Outgoing *message) {
         int r;

--- a/src/n-dhcp4-c-probe.c
+++ b/src/n-dhcp4-c-probe.c
@@ -704,7 +704,7 @@ static int n_dhcp4_client_probe_transition_deferred(NDhcp4ClientProbe *probe, ui
         switch (probe->state) {
         case N_DHCP4_CLIENT_PROBE_STATE_INIT:
                 /* reset client IP (CIADDR) */
-                probe->connection.client_ip = INADDR_ANY;
+                n_dhcp4_c_connection_clear_client_ip(&probe->connection);
                 r = n_dhcp4_c_connection_listen(&probe->connection);
                 if (r)
                         return r;

--- a/src/n-dhcp4-private.h
+++ b/src/n-dhcp4-private.h
@@ -617,6 +617,8 @@ void n_dhcp4_c_connection_close(NDhcp4CConnection *connection);
 void n_dhcp4_c_connection_get_timeout(NDhcp4CConnection *connection,
                                       uint64_t *timeoutp);
 
+void n_dhcp4_c_connection_clear_client_ip(NDhcp4CConnection *connection);
+
 int n_dhcp4_c_connection_discover_new(NDhcp4CConnection *connection,
                                       NDhcp4Outgoing **request);
 int n_dhcp4_c_connection_select_new(NDhcp4CConnection *connection,


### PR DESCRIPTION
Do not set ciaddr in DISCOVER state. As this is invalid according to RFC 2131 table 1 ("Description of fields in a DHCP message") and has previously been discussed in #45.

I've been seeing similar behavior to what has been described in the above-mentioned issue on Ubuntu Core 20, using NetworkManager 1.22.10. It looks like the discussion on the mailing list went nowhere and the suggested fix of modifying `n_dhcp4_c_connection_init_header()` didn't work, as in that function we do not yet know about the `type` of the message.

So I tried experimenting a bit and came up with this draft of checking for `type == N_DHCP4_C_MESSAGE_DISCOVER` afterward and dropping the `ciaddr` (and reset the `client_ip`), so we do not include the "Client-IP" in any messages, until we receive another DHCP-ACK.

Not sure if this is the best approach. Please let me know what you think.