### PR TITLE
dhcp: Fix ciaddr field to comply with RFC2131

### DIFF
--- a/src/n-dhcp4-c-connection.c
+++ b/src/n-dhcp4-c-connection.c
@@ -430,7 +430,8 @@ static int n_dhcp4_c_connection_udp_send(NDhcp4CConnection *connection,
 }
 
 static void n_dhcp4_c_connection_init_header(NDhcp4CConnection *connection,
-                                             NDhcp4Header *header) {
+                                             NDhcp4Header *header,
+                                             uint8_t type) {
         bool broadcast = connection->client_config->request_broadcast;
 
         header->op = N_DHCP4_OP_BOOTREQUEST;
@@ -455,22 +456,37 @@ static void n_dhcp4_c_connection_init_header(NDhcp4CConnection *connection,
                 break;
         }
 
-        if (connection->client_ip != INADDR_ANY) {
+        /*
+         * Set ciaddr according to RFC2131 section 4:
+         * - must be zero for initial messages (DISCOVER, SELECT)
+         * - must be zero for REBOOT and DECLINE
+         * - must be client's IP for all other messages (RENEW, REBIND, RELEASE, INFORM)
+         */
+        switch (type) {
+        case N_DHCP4_C_MESSAGE_DISCOVER:    /* 4.4.1 - must be zero */
+        case N_DHCP4_C_MESSAGE_SELECT:      /* 4.3.2 - must be zero in SELECTING */
+        case N_DHCP4_C_MESSAGE_REBOOT:      /* 4.3.2 - must be zero in INIT-REBOOT */
+        case N_DHCP4_C_MESSAGE_DECLINE:     /* 4.4   - must be zero per RFC2131 table */
+                header->ciaddr = INADDR_ANY;
+                break;
+        default:
+                /* All other message types must use client's current IP */
                 header->ciaddr = connection->client_ip;
-        } else {
-                /*
-                 * When the IP stack has not been configured, we may
-                 * not be able to receive unicast packets, depending
-                 * on the hardware. If that is the case we must request
-                 * replies from the server to be broadcast.
-                 *
-                 * Once the IP stack has been configured, receiving
-                 * unicast packets is never a problem, so the broadcast
-                 * flag should not be set.
-                 */
-                if (broadcast)
-                        header->flags |= N_DHCP4_MESSAGE_FLAG_BROADCAST;
+                break;
         }
+
+        /*
+         * When the IP stack has not been configured, we may
+         * not be able to receive unicast packets, depending
+         * on the hardware. If that is the case we must request
+         * replies from the server to be broadcast.
+         *
+         * Once the IP stack has been configured, receiving
+         * unicast packets is never a problem, so the broadcast
+         * flag should not be set.
+         */
+        if (connection->client_ip == INADDR_ANY && broadcast)
+                header->flags |= N_DHCP4_MESSAGE_FLAG_BROADCAST;
 }
 
 static int n_dhcp4_c_connection_new_message(NDhcp4CConnection *connection,
@@ -535,7 +551,7 @@ static int n_dhcp4_c_connection_new_message(NDhcp4CConnection *connection,
                 return r;
 
         header = n_dhcp4_outgoing_get_header(message);
-        n_dhcp4_c_connection_init_header(connection, header);
+        n_dhcp4_c_connection_init_header(connection, header, type);
 
         message->userdata.type = type;
         message->userdata.message_type = message_type;


### PR DESCRIPTION
This MR fixes remaining RFC2131 compliance issues with the `ciaddr` field in DHCP packets.

While the recent fix (#48) correctly addressed resetting `client_ip` during INIT, there were still cases where `ciaddr` was incorrectly set despite RFC2131 requirements.

This is a proposal to address the concerns raised in #50.

Key changes:
- Add message type parameter to header initialization function
- Implement explicit `ciaddr` handling based on message type
- Maintain separation between:
  * `client_ip`: represents actual connection/IP stack state
  * `ciaddr`: protocol field following RFC2131 requirements
- Preserve broadcast flag logic based on IP stack configuration

This change complements the previous fix by:
1. Preserving internal state when needed (for requested IP option)
2. Ensuring RFC compliance for protocol fields
3. Making the code more explicit about state vs protocol requirements
4. Maintaining existing broadcast behavior based on actual network stack state

The implementation strictly follows RFC2131 section 4 rules for `ciaddr` field usage in different message types and states, while keeping the broadcast flag logic tied to the actual ability to receive unicast packets.

This is a draft for discussion about the approach before proceeding with complete testing and validation.