### PR TITLE
ci: enforce clang-format on src tree

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,13 @@
+AlignAfterOpenBracket: Align
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BasedOnStyle: LLVM
+BreakBeforeBraces: Attach
+ColumnLimit: 0
+ContinuationIndentWidth: 8
+IndentWidth: 8
+PointerAlignment: Right
+SortIncludes: false
+SpaceAfterCStyleCast: false
+UseTab: Never

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: clang-format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
     - name: Check formatting of changed lines
@@ -28,43 +28,20 @@ jobs:
         fi
 
   ci:
-    name: CI with Default Configuration
+    name: Build and Test
     runs-on: ubuntu-latest
-
     steps:
-    #
-    # Prepare CI
-    #
-    # We cannot use the github-action of the `ci-c-util` project, because we
-    # need privileges in the container. Therefore, fetch the CI sources and
-    # build the container manually.
-    #
-    - name: Fetch CI
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v7
       with:
-        repository: c-util/automation
-        ref: v1
-        path: automation
-    - name: Build CI
-      working-directory: automation/src/ci-c-util
-      run: docker build --tag ci-c-util:v1 .
-
-    #
-    # Run CI
-    #
-    # Take the CI image we built and run the CI with the default project
-    # configuration. We do not use valgrind, since it falls-over with bpf(2)
-    # syscalls.
-    #
-    - name: Fetch Sources
-      uses: actions/checkout@v2
-      with:
-        path: source
-    - name: Run through C-Util CI
+        submodules: recursive
+    - name: Install build dependencies
+      run: sudo apt-get update && sudo apt-get install -y meson ninja-build gcc
+    - name: Build
       run: |
-        docker run \
-                --privileged \
-                -v "$(pwd)/source:/github/workspace" \
-                "ci-c-util:v1" \
-                "--m32=1" \
-                "--source=/github/workspace"
+        meson setup build
+        meson compile -C build
+    - name: Test
+      # tests create network namespaces and AF_PACKET sockets (src/util/netns.c,
+      # src/n-dhcp4-socket.c), so they need root on the runner, as the old
+      # c-util container ran --privileged
+      run: sudo meson test -C build --print-errorlogs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,26 @@ on:
   - cron:  '0 0 * * *'
 
 jobs:
+  format:
+    name: clang-format
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Check formatting of changed lines
+      run: |
+        sudo apt-get update && sudo apt-get install -y clang-format
+        base="${{ github.event.pull_request.base.sha }}"
+        [ -n "$base" ] || base="$(git rev-parse HEAD^)"
+        fmt="$(git diff -U0 --no-color "$base"...HEAD -- 'src/*.c' 'src/*.h' \
+                 | clang-format-diff -p1 -style=file)"
+        if [ -n "$fmt" ]; then
+          echo "Changed lines are not clang-formatted:"
+          echo "$fmt"
+          exit 1
+        fi
+
   ci:
     name: CI with Default Configuration
     runs-on: ubuntu-latest

--- a/src/n-dhcp4-c-probe.c
+++ b/src/n-dhcp4-c-probe.c
@@ -1330,7 +1330,7 @@ int n_dhcp4_client_probe_update_mtu(NDhcp4ClientProbe *probe, uint16_t mtu) {
  *
  * Return: 0 if successful otherwise non-zero value is returned.
  */
- int n_dhcp4_client_probe_release(NDhcp4ClientProbe *probe) {
+int n_dhcp4_client_probe_release(NDhcp4ClientProbe *probe) {
         _c_cleanup_(n_dhcp4_outgoing_freep) NDhcp4Outgoing *request_out = NULL;
         int r;
 


### PR DESCRIPTION
While re-importing the vendored nettools and c-util dep subtrees into NetworkManager, I noticed a leading space slipped in. (fixed in: 9879dad44152e28e22a5bdd5cdcdc4fb49d2cfb7)

Therefore, I'd also like to propose we run clang-format on PRs to catch this in ci + I replaced the now deprecated c-utils automation in the ci